### PR TITLE
feat: add FCM v1 API platform configs support

### DIFF
--- a/src/FcmService.php
+++ b/src/FcmService.php
@@ -117,6 +117,26 @@ class FcmService
             ],
         ];
 
+        if (isset($data['data'])) {
+            $message['message']['data'] = $data['data'];
+        }
+
+        if (isset($data['android'])) {
+            $message['message']['android'] = $data['android'];
+        }
+
+        if (isset($data['webpush'])) {
+            $message['message']['webpush'] = $data['webpush'];
+        }
+
+        if (isset($data['apns'])) {
+            $message['message']['apns'] = $data['apns'];
+        }
+
+        if (isset($data['fcm_options'])) {
+            $message['message']['fcm_options'] = $data['fcm_options'];
+        }
+
         $response = Http::withToken($this->accessToken)->post($url, $message);
 
         return $response->json();


### PR DESCRIPTION
Add support for data, android, webpush, apns, and fcm_options fields to comply with Firebase Cloud Messaging HTTP v1 API specification.

## Reference
- [FCM REST API Documentation](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages)